### PR TITLE
feat(queue): add timing metrics and return them in prometheus export

### DIFF
--- a/src/classes/queue-getters.ts
+++ b/src/classes/queue-getters.ts
@@ -553,6 +553,27 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
     };
   }
 
+  /**
+   * Get execution time percentiles for all jobs (completed and failed combined).
+   * This method does not modify the data and is safe to call from multiple
+   * Prometheus exporters simultaneously.
+   *
+   * @param timeWindowSeconds - How many seconds back to look (default: 900 = 15 minutes)
+   * @param bucketSizeSeconds - Bucket size in seconds (should match your metrics configuration, default: 15)
+   * @returns Object with p50, p95, p99 percentiles and sample count
+   */
+  async getExecutionTimePercentiles(
+    timeWindowSeconds = 900,
+    bucketSizeSeconds = 15,
+  ): Promise<{ p50: number; p95: number; p99: number; count: number }> {
+    const [p50, p95, p99, count] = await this.scripts.getExecutionPercentiles(
+      timeWindowSeconds,
+      bucketSizeSeconds,
+    );
+
+    return { p50, p95, p99, count };
+  }
+
   private parseClientList(list: string, matcher: (name: string) => boolean) {
     const lines = list.split(/\r?\n/);
     const clients: { [index: string]: string }[] = [];
@@ -580,7 +601,9 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
    * Export the metrics for the queue in the Prometheus format.
    * Automatically exports all the counts returned by getJobCounts().
    * Includes the counter of "completed" and "failed" jobs if metrics are enabled.
+   * Includes job execution time percentiles if timing collection is enabled.
    *
+   * @param globalVariables - Additional labels to add to all metrics
    * @returns - Returns a string with the metrics in the Prometheus format.
    *
    * @see {@link https://prometheus.io/docs/instrumenting/exposition_formats/}
@@ -588,6 +611,18 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
    **/
   async exportPrometheusMetrics(
     globalVariables?: Record<string, string>,
+    timingMetricsOptions?: {
+      /**
+       * How many seconds back to look (default: 30s).
+       * Should be 2x the bucket size to handle Prometheus scraping timing variations.
+       */
+      timeWindowSeconds?: number;
+      /**
+       * Bucket size in seconds (default: 15s).
+       * Must match the timingBucketSeconds configured in your worker metrics options.
+       */
+      bucketSizeSeconds?: number;
+    },
   ): Promise<string> {
     const counts = await this.getJobCounts();
     const metrics: string[] = [];
@@ -637,6 +672,49 @@ export class QueueGetters<JobBase extends Job = Job> extends QueueBase {
     metrics.push(
       `bullmq_job_amount{queue="${this.name}", state="failed"${variables}} ${failedMetricsCounter}`,
     );
+
+    // Add execution time percentiles if timing collection is enabled
+    try {
+      const bucketSize = timingMetricsOptions?.bucketSizeSeconds ?? 15;
+      const timeWindow =
+        timingMetricsOptions?.timeWindowSeconds ?? bucketSize * 3;
+
+      const timings = await this.getExecutionTimePercentiles(
+        timeWindow,
+        bucketSize,
+      );
+
+      metrics.push(
+        '# HELP bullmq_job_duration_percentiles Job execution time percentiles in milliseconds',
+      );
+      metrics.push('# TYPE bullmq_job_duration_percentiles gauge');
+
+      // Add percentile metrics
+      metrics.push(
+        `bullmq_job_duration_percentiles{queue="${this.name}", percentile="50"${variables}} ${timings.p50}`,
+      );
+      metrics.push(
+        `bullmq_job_duration_percentiles{queue="${this.name}", percentile="95"${variables}} ${timings.p95}`,
+      );
+      metrics.push(
+        `bullmq_job_duration_percentiles{queue="${this.name}", percentile="99"${variables}} ${timings.p99}`,
+      );
+
+      // Add sample count for observability
+      metrics.push(
+        '# HELP bullmq_job_duration_samples Number of timing samples used for percentile calculation',
+      );
+      metrics.push('# TYPE bullmq_job_duration_samples gauge');
+      metrics.push(
+        `bullmq_job_duration_samples{queue="${this.name}"${variables}} ${timings.count}`,
+      );
+    } catch (error) {
+      // Log error but don't fail the entire metrics export
+      console.warn(
+        `Failed to collect timing metrics for queue ${this.name}:`,
+        error,
+      );
+    }
 
     return metrics.join('\n');
   }

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1043,4 +1043,24 @@ export class Queue<
     const client = await this.client;
     return client.del(this.toKey('priority'));
   }
+
+  /**
+   * Deletes all saved metrics for a queue.
+   */
+  async resetMetrics(): Promise<void> {
+    const client = await this.client;
+    const multi = client.multi();
+
+    const { metricsKey: metricsKeyCompleted, dataKey: dataKeyCompleted } =
+      this.getMetricsKeys('completed');
+    const { metricsKey: metricsKeyFailed, dataKey: dataKeyFailed } =
+      this.getMetricsKeys('failed');
+
+    multi.del(metricsKeyCompleted);
+    multi.del(dataKeyCompleted);
+    multi.del(metricsKeyFailed);
+    multi.del(dataKeyFailed);
+
+    await multi.exec();
+  }
 }

--- a/src/commands/getExecutionPercentiles-1.lua
+++ b/src/commands/getExecutionPercentiles-1.lua
@@ -1,0 +1,68 @@
+--[[
+  Calculate execution time percentiles from time-bucketed keys
+  
+  Input:
+    KEYS[1] metrics key prefix (e.g., "bull:myqueue:metrics")
+    
+    ARGV[1] timeWindowSeconds - how many seconds back to look
+    ARGV[2] currentTimestamp - current timestamp in milliseconds
+    ARGV[3] bucketSizeSeconds - bucket size in seconds
+    
+  Output:
+    [p50, p95, p99, sampleCount]
+    
+  Example:
+    EVAL script 1 "bull:myqueue:metrics" 900 1640995200000 15
+]]
+
+local rcall = redis.call
+local metricsKeyPrefix = KEYS[1]
+local timeWindowSeconds = tonumber(ARGV[1]) or 30  -- Default 30 seconds (2 buckets) to handle Prometheus scraping timing variations
+local currentTimestamp = tonumber(ARGV[2])
+local bucketSizeSeconds = tonumber(ARGV[3]) or 15
+
+-- Collect all execution times from time buckets
+local allTimings = {}
+local totalSamples = 0
+
+local bucketSizeMs = bucketSizeSeconds * 1000
+local numBuckets = math.floor(timeWindowSeconds / bucketSizeSeconds)
+
+for i = 0, numBuckets - 1 do
+    local bucketTime = math.floor((currentTimestamp - (i * bucketSizeMs)) / bucketSizeMs) * bucketSizeMs
+    local timingKey = metricsKeyPrefix .. ":timings:" .. bucketTime
+    
+    -- Get all execution times from this bucket (stored as list values)
+    local bucketTimings = rcall("LRANGE", timingKey, 0, -1)
+    
+    -- Add all timing values to our collection
+    for j = 1, #bucketTimings do
+        local executionTime = tonumber(bucketTimings[j])
+        if executionTime then
+            table.insert(allTimings, executionTime)
+            totalSamples = totalSamples + 1
+        end
+    end
+end
+
+-- Return zeros if no data
+if totalSamples == 0 then
+    return {0, 0, 0, 0}
+end
+
+-- Sort the timings array
+table.sort(allTimings)
+
+-- Calculate percentiles
+local function calculatePercentile(sortedArray, percentile)
+    local index = math.ceil((percentile / 100) * #sortedArray)
+    -- Ensure index is within bounds
+    index = math.max(1, math.min(index, #sortedArray))
+    return sortedArray[index]
+end
+
+local p50 = calculatePercentile(allTimings, 50)
+local p95 = calculatePercentile(allTimings, 95)
+local p99 = calculatePercentile(allTimings, 99)
+
+return {p50, p95, p99, totalSamples}

--- a/src/interfaces/metrics-options.ts
+++ b/src/interfaces/metrics-options.ts
@@ -1,6 +1,5 @@
 /**
- *
- *
+ * Options for collecting queue metrics
  */
 export interface MetricsOptions {
   /**
@@ -9,4 +8,22 @@ export interface MetricsOptions {
    * failed.
    */
   maxDataPoints?: number;
+
+  /**
+   * Enable collection of job execution time metrics.
+   * When enabled, execution times will be stored in Redis
+   * for percentile calculations.
+   *
+   * @defaultValue false
+   */
+  collectTimings?: boolean;
+
+  /**
+   * Time bucket size in seconds for timing metrics collection.
+   * Smaller buckets provide more granular data but use more memory.
+   * Should match your Prometheus scraping interval.
+   *
+   * @defaultValue 15
+   */
+  timingBucketSeconds?: number;
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a PR! 
  Please fill out all sections below to help us understand your changes.
-->

### Why
<!-- 
  1. Why is this change necessary?
  2. What problem does it solve or improve?
  3. Link to any relevant issues, if applicable.
-->
To collect job timings. Before I used a custom prometheus exporter that would run on a global .on('finish') handler collecting each job on its own (which only worked with removeOnComplete/removeOnFail set to false). After each collection I would call job.remove() which causes unnecessary load on redis as I don't even need to keep the jobs with this change in the first place

### How
<!--
  1. How did you implement this?
  2. Outline the approach or steps taken.
  3. List any resources or documentation that helped you.
-->
- each onFinish calls LPUSH for the execution time to a metrics bucket with a configurable size (default 15s)
- a new lua function calculates the percentile values in redis (to avoid network overhead of potential hundreds of thousands of items from the redis list)
- TTL on these buckets cleans up after itself
- to avoid timeframe overlaps of buckets and prometheus timing (e.g. bucket is 15s from 00:00:00 to 00:00:15, prometheus queries at 00:00:02, it would only gather 2s of data) it fetches 2 buckets by default, but can be configured to custom value
- adds new metrics for the timing of the jobs to be able to monitor p50, p95 and p99 per queue
- exposes the counter of how many jobs completed/failed in the prometheus exporter
- exposes the p50/p95/p99 values in the prometheus exporter

### Additional Notes (Optional)
<!--
  Use this space for additional considerations: 
  - Potential side effects
  - Dependencies 
  - Testing instructions
  - Anything else reviewers should know
-->
_Any extra info here._
